### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,10 @@
   "test_pattern": "TODO",
   "exercises": [
     {
+      "uuid": "c81c4175-f06b-404d-8c01-c4a6dba661d3",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "word definition",
@@ -14,7 +17,10 @@
       ]
     },
     {
+      "uuid": "17fb2814-2164-4933-8f72-adeb9b2b5ccf",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "quotations",
@@ -24,7 +30,10 @@
       ]
     },
     {
+      "uuid": "22c5c529-07bb-4df2-8d2f-e470d1ed48da",
       "slug": "two-fer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "word definition",
@@ -34,17 +43,17 @@
       ]
     },
     {
+      "uuid": "d3afeeb3-8c4e-4a31-81a2-fb039ab3c5af",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-          "word definition",
-          "stack effect",
-          "strings"
+        "word definition",
+        "stack effect",
+        "strings"
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16