### PR TITLE
two-fer: fix installing link in README.md

### DIFF
--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -43,7 +43,7 @@ readable as we can.
 
 ## Testing Exercises
 
-If you followed the [installation instructions](http://exercism.io/languages/factor/installing), just run the provided test suite against your implementation with `"exercise-name" test`.
+If you followed the [installation instructions](http://exercism.io/languages/factor/installation), just run the provided test suite against your implementation with `"exercise-name" test`.
 
 ## Submitting Exercises
 


### PR DESCRIPTION
Fixes a broken link to the install documentation in two-fer