### PR TITLE
Reformat config files

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,59 +1,57 @@
 {
   "language": "Factor",
   "active": false,
+  "blurb": "",
   "test_pattern": "-tests[.]factor",
   "exercises": [
     {
-      "uuid": "c81c4175-f06b-404d-8c01-c4a6dba661d3",
       "slug": "hello-world",
+      "uuid": "c81c4175-f06b-404d-8c01-c4a6dba661d3",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "word definition",
-        "stack effect"
+        "stack_effect",
+        "word_definition"
       ]
     },
     {
-      "uuid": "17fb2814-2164-4933-8f72-adeb9b2b5ccf",
       "slug": "leap",
+      "uuid": "17fb2814-2164-4933-8f72-adeb9b2b5ccf",
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "quotations",
-        "word definition",
         "conditionals",
-        "logical operators"
+        "logical_operators",
+        "quotations",
+        "word_definition"
       ]
     },
     {
-      "uuid": "22c5c529-07bb-4df2-8d2f-e470d1ed48da",
       "slug": "two-fer",
+      "uuid": "22c5c529-07bb-4df2-8d2f-e470d1ed48da",
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "word definition",
-        "stack effect",
-        "text formatting",
-        "quotations"
+        "quotations",
+        "stack_effect",
+        "text_formatting",
+        "word_definition"
       ]
     },
     {
-      "uuid": "d3afeeb3-8c4e-4a31-81a2-fb039ab3c5af",
       "slug": "isogram",
+      "uuid": "d3afeeb3-8c4e-4a31-81a2-fb039ab3c5af",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "word definition",
-        "stack effect",
-        "strings"
+        "stack_effect",
+        "strings",
+        "word_definition"
       ]
     }
-  ],
-  "foregone": [
-
   ]
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,15 +1,15 @@
 {
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
   "maintainers": [
     {
       "github_username": "catb0t",
-      "show_on_website": false,
       "alumnus": false,
+      "show_on_website": false,
       "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "avatar_url": null,
+      "bio": null
     }
-  ],
-  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+  ]
 }


### PR DESCRIPTION
This runs the configlet fmt command, which normalizes the
contents and ordering of keys in the track config and
maintainers config.

This will let us script changes to the config files without
having unnecessary noise in the diffs when submitting pull
requests.

See exercism/meta#95