### PR TITLE
Fix broken links for test setup

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -16,11 +16,11 @@ Words written in this way will implicitly be easily `unit-test`able.
 
 Unit tests (usually a bunch of assertions like above) go in a file called `vocab-name-tests.factor` beside your implementation `vocab-name.factor`. This file is already created for you by Exercism, but would normally need to be created by hand, or by `"exercise" scaffold-tests`.
 
-Get the [`tools.test` wrapper library for Exercism](https://github.com/catb0t/exercism.testing), and put its `exercism` subfolder inside Factor's `work` folder, such that `testing.factor` is located at `resource:work/exercism/testing/testing.factor`.
+Get the [`tools.test` wrapper library for Exercism](https://github.com/catb0t/exercism.factor), and put its `exercism` subfolder inside Factor's `work` folder, such that `testing.factor` is located at `resource:work/exercism/testing/testing.factor`.
 
 When the current directory is your `exercism/factor` exercises folder:
 
 * Run a vocabulary's tests from the listener with `USE: exercism.testing "exercise-name" run-exercism-test`, or from the command-line with `factor -run=exercism.testing exercise-name`.
 * Run all tests for all exercises with `USE: exercism.testing run-all-exercism-tests` or from the command-line with `factor -run=exercism.testing run-all`.
 
-For more information, see the Factor documentation on [Unit testing](http://docs.factorcode.org/content/article-tools.test.html), and [`exercism.testing`](https://github.com/catb0t/exercism.testing)'s documentation with `"exercism.testing" help`.
+For more information, see the Factor documentation on [Unit testing](http://docs.factorcode.org/content/article-tools.test.html), and [`exercism.testing`](https://github.com/catb0t/exercism.factor/tree/HEAD/exercism/testing)'s documentation with `"exercism.testing" help`.


### PR DESCRIPTION
Looks like the test wrapper links were either typo'd or have changed

It looks like this is where they should point: https://github.com/catb0t/exercism.factor