### PR TITLE
Remove travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: bash
-
-script:
-  - bin/fetch-configlet
-  - bin/configlet lint .


### PR DESCRIPTION
Configlet fails because it no longer needs a `.` argument, but also this exists:

https://github.com/exercism/factor/blob/main/.github/workflows/configlet.yml

So the `.travis.yml` appears unnecessary now.