### PR TITLE
leap: sync

### DIFF
--- a/exercises/practice/leap/.docs/instructions.md
+++ b/exercises/practice/leap/.docs/instructions.md
@@ -1,24 +1,3 @@
 # Instructions
 
-Given a year, report if it is a leap year.
-
-The tricky thing here is that a leap year in the Gregorian calendar occurs:
-
-```text
-on every year that is evenly divisible by 4
-  except every year that is evenly divisible by 100
-    unless the year is also evenly divisible by 400
-```
-
-For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
-year, but 2000 is.
-
-## Notes
-
-Though our exercise adopts some very simple rules, there is more to
-learn!
-
-For a delightful, four minute explanation of the whole leap year
-phenomenon, go watch [this youtube video][video].
-
-[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+Your task is to determine whether a given year is a leap year.

--- a/exercises/practice/leap/.docs/introduction.md
+++ b/exercises/practice/leap/.docs/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+A leap year (in the Gregorian calendar) occurs:
+
+- In every year that is evenly divisible by 4.
+- Unless the year is evenly divisible by 100, in which case it's only a leap year if the year is also evenly divisible by 400.
+
+Some examples:
+
+- 1997 was not a leap year as it's not divisible by 4.
+- 1900 was not a leap year as it's not divisible by 400.
+- 2000 was a leap year!
+
+~~~~exercism/note
+For a delightful, four-minute explanation of the whole phenomenon of leap years, check out [this YouTube video](https://www.youtube.com/watch?v=xX96xng7sAE).
+~~~~

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/leap-example.factor"
     ]
   },
-  "blurb": "Given a year, report if it is a leap year.",
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "blurb": "Determine whether a given year is a leap year.",
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
 }


### PR DESCRIPTION
Sync the `leap` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/leap.