### PR TITLE
two-fer: sync

### DIFF
--- a/exercises/practice/two-fer/.docs/instructions.md
+++ b/exercises/practice/two-fer/.docs/instructions.md
@@ -2,14 +2,13 @@
 
 Your task is to determine what you will say as you give away the extra cookie.
 
-If your friend likes cookies, and is named Do-yun, then you will say:
+If you know the person's name (e.g. if they're named Do-yun), then you will say:
 
 ```text
 One for Do-yun, one for me.
 ```
 
-If your friend doesn't like cookies, you give the cookie to the next person in line at the bakery.
-Since you don't know their name, you will say _you_ instead.
+If you don't know the person's name, you will say _you_ instead.
 
 ```text
 One for you, one for me.
@@ -17,9 +16,9 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    |Dialogue
-|:-------|:------------------
-|Alice   |One for Alice, one for me.
-|Bohdan  |One for Bohdan, one for me.
-|        |One for you, one for me.
-|Zaphod  |One for Zaphod, one for me.
+| Name   | Dialogue                    |
+| :----- | :-------------------------- |
+| Alice  | One for Alice, one for me.  |
+| Bohdan | One for Bohdan, one for me. |
+|        | One for you, one for me.    |
+| Zaphod | One for Zaphod, one for me. |

--- a/exercises/practice/two-fer/.docs/introduction.md
+++ b/exercises/practice/two-fer/.docs/introduction.md
@@ -5,4 +5,4 @@ Two-for-one is a way of saying that if you buy one, you also get one for free.
 So the phrase "two-fer" often implies a two-for-one offer.
 
 Imagine a bakery that has a holiday offer where you can buy two cookies for the price of one ("two-fer one!").
-You go for the offer and (very generously) decide to give the extra cookie to a friend.
+You take the offer and (very generously) decide to give the extra cookie to someone else in the queue.

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -16,6 +16,6 @@
       ".meta/two-fer-example.factor"
     ]
   },
-  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "blurb": "Create a sentence of the form \"One for X, one for me.\".",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }


### PR DESCRIPTION
Sync the `two-fer` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer.

- Feel free to close this PR if there is another PR that also syncs this exercise.
- When approved, feel free to merge this PR yourselves (you don't have to wait for me).

As this PR only updates docs and/or metadata, it won't trigger a re-run of existing solutions (see [the docs](https://exercism.org/docs/building/tracks)).