### PR TITLE
Fix CI: expect v3 results.json and run on amd64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/bin/.test-in-docker
+++ b/bin/.test-in-docker
@@ -17,12 +17,18 @@ for slug in $all_slugs; do
   # their solution.
   cp /tmp/solution/.meta/example.factor "/tmp/solution/${slug}/${slug}.factor"
   bin/run.sh "${slug}" /tmp/solution /tmp/solution > /dev/null
-  solution_pattern=$(jq -r tostring /tmp/solution/results.json | grep "{\"version\":1,\"status\":\"pass\"")
+  top_status=$(jq -r '.status' /tmp/solution/results.json)
 
   errors=""
 
-  if [ -z "$solution_pattern" ]; then
-    errors="${errors}\n\nSolution is incorrect:\n$(jq -r '.message' /tmp/solution/results.json)"
+  if [ "$top_status" != "pass" ]; then
+    msg=$(jq -r '
+      if .message then .message
+      else (.tests // [] | map(select(.status != "pass")
+              | "  \(.name): \(.message // "no message")")
+            | join("\n"))
+      end' /tmp/solution/results.json)
+    errors="${errors}\n\nSolution is incorrect:\n${msg}"
     local_exit_code=1;
   fi
 


### PR DESCRIPTION
## Summary
- `bin/.test-in-docker` now reads top-level `.status` from the v3 `results.json` instead of grepping for the old v1 shape, so passing example solutions are recognised again. On failure it surfaces either the top-level `.message` (error case) or the per-test `.message` values (fail case).
- `.github/workflows/test.yml` runs on `ubuntu-24.04` rather than `ubuntu-24.04-arm`, matching the amd64-only image currently published on Docker Hub. This avoids running the Factor VM under QEMU emulation.

The May rewrite of [`factor-test-runner`](https://github.com/exercism/factor-test-runner) switched the runner's output to `{"version":3, ...}`. The integration check in this repo still grepped for `{"version":1,"status":"pass"}`, which never matched — so every exercise printed `Solution is incorrect: null` (a passing v3 result has no top-level `.message`, so `jq -r '.message'` yields `null`). Last green CI run was 2026-05-02 (#188), immediately before those runner changes landed.

## Test plan
- [ ] CI on this PR runs `Track Exercises on Runner` to green