### PR TITLE
joiners-journey: clean up forward references

### DIFF
--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -5,6 +5,7 @@ Factor's numeric tower includes integers, ratios, and floats:
 ```factor
 2 3 + .       ! => 5
 1 2 / .       ! => 1/2     (rational, not 0)
+5 2 / .       ! => 2+1/2   (improper ratios print as mixed numerals)
 2.0 3.0 + .   ! => 5.0
 ```
 

--- a/exercises/concept/boutique-bookkeeping/.docs/introduction.md
+++ b/exercises/concept/boutique-bookkeeping/.docs/introduction.md
@@ -163,7 +163,7 @@ USING: math.statistics sequences ;
     map-sum ; inline
 
 { { "shirt" 20 } { "hat" 15 } } [ second 1/10 * ] tax-on .
-! => 7/2
+! => 3+1/2
 ```
 
 Words built only from literal quotations don't need `inline` —

--- a/exercises/concept/currency-conversion/.docs/introduction.md
+++ b/exercises/concept/currency-conversion/.docs/introduction.md
@@ -32,7 +32,8 @@ mod  ( x y -- r   )    ! remainder
 ```
 
 ```factor
-16 3 / .       ! => 16/3   (a rational; print as a fraction)
+1 2 / .        ! => 1/2     (a proper ratio)
+16 3 / .       ! => 5+1/3   (an improper ratio, printed as a mixed numeral)
 16 3 /f .      ! => 5.333333333333333
 16 3 /i .      ! => 5      (truncated)
 16 3 mod .     ! => 1

--- a/exercises/concept/joiners-journey/.docs/instructions.md
+++ b/exercises/concept/joiners-journey/.docs/instructions.md
@@ -9,7 +9,7 @@ The previous apprentice left the till code in a jungle of `dup`,
 `over`, `swap`, and `rot`. Your job is to rewrite five small words
 using *combinators*.
 
-Each board enters the workflow with just its raw `length` (cm) on
+Each board enters the workflow with just its raw length (cm) on
 the stack.
 
 ## 1. Add the kerf allowance

--- a/exercises/concept/joiners-journey/.docs/introduction.md
+++ b/exercises/concept/joiners-journey/.docs/introduction.md
@@ -62,7 +62,7 @@ keep ( x quot: ( x -- y ) -- y x )
 ```
 
 That replaces a `dup`-followed-by-something-then-shuffle
-pattern: anywhere you'd write `dup [ something ] dip`, you can
+pattern: anywhere you'd write `dup something swap`, you can
 just say `[ something ] keep`.
 
 ## `bi` — two functions of one input
@@ -149,8 +149,24 @@ bi@ ( x y quot -- r1 r2 )
 ! => 16
 ```
 
-Compare with `bi*`, which applies *different* quotations to the
-two values.
+## `bi*` — different operations on two values
+
+`bi*` (in [`kernel`][kernel]) applies *different* quotations to the
+two stack values — the first quotation to the lower value, the
+second to the top:
+
+```
+bi* ( x y q1 q2 -- r1 r2 )
+```
+
+```factor
+3 4 [ sq ] [ neg ] bi* .s
+! => 9
+! => -4
+```
+
+Reach for `bi@` when both values get the same treatment, and for
+`bi*` when each needs its own.
 
 [kernel]: https://docs.factorcode.org/content/vocab-kernel.html
 [combinators]: https://docs.factorcode.org/content/vocab-combinators.html


### PR DESCRIPTION
- instructions.md: drop the backticks around "length", which made it read like a reference to the sequences word `length`
- introduction.md: in the `keep` paragraph, use `dup something swap` rather than `dup [ something ] dip` as the pattern that `keep` replaces. `dip` is introduced two sections later, so referencing it here was a forward dependency.