### PR TITLE
belgian-boxcars: mention splitting.monotonic

### DIFF
--- a/config.json
+++ b/config.json
@@ -876,13 +876,13 @@
         "name": "Rotational Cipher",
         "uuid": "dc8ef2d7-065e-4ea5-b613-6f4db433e925",
         "practices": [
-          "strings"
+          "curry-compose-fry"
         ],
         "prerequisites": [
           "curry-compose-fry",
-          "strings",
-          "unicode",
-          "locals"
+          "mutation",
+          "reductions",
+          "tabulation"
         ],
         "difficulty": 3
       },

--- a/exercises/concept/belgian-boxcars/.docs/introduction.md
+++ b/exercises/concept/belgian-boxcars/.docs/introduction.md
@@ -1,9 +1,10 @@
 # Introduction
 
 Sometimes you need to view a sequence as a series of *pieces*
-rather than element-by-element. The
-[`grouping`][grouping] and [`splitting`][splitting] vocabularies
-give you four ways to do that.
+rather than element-by-element. The [`grouping`][grouping],
+[`splitting`][splitting], and
+[`splitting.monotonic`][splitting.monotonic] vocabularies give
+you four ways to do that.
 
 ## `group` — disjoint chunks of size *n*
 
@@ -79,3 +80,4 @@ non-decreasing runs; and so on.
 
 [grouping]: https://docs.factorcode.org/content/vocab-grouping.html
 [splitting]: https://docs.factorcode.org/content/vocab-splitting.html
+[splitting.monotonic]: https://docs.factorcode.org/content/vocab-splitting.monotonic.html

--- a/exercises/concept/coordinate-choreography/.docs/hints.md
+++ b/exercises/concept/coordinate-choreography/.docs/hints.md
@@ -36,6 +36,17 @@
   to multiply each component by its coefficient. Wrap with `+` and
   `2array` to assemble the result.
 
+## 6. Transform many points at once
+
+- `map` (in [`sequences`][sequences]) walks the sequence and
+  applies a quotation to each element.
+- That per-element quotation needs to know which transformation
+  to use — same `curry`-or-fry capture you used in tasks 1 and 2,
+  just applied at the per-element level instead of the whole
+  transformation.
+- `apply-transformation` from task 4 is the natural body.
+
 [arrays]: https://docs.factorcode.org/content/vocab-arrays.html
 [kernel]: https://docs.factorcode.org/content/vocab-kernel.html
 [math.vectors]: https://docs.factorcode.org/content/vocab-math.vectors.html
+[sequences]: https://docs.factorcode.org/content/vocab-sequences.html

--- a/exercises/concept/coordinate-choreography/.docs/introduction.md
+++ b/exercises/concept/coordinate-choreography/.docs/introduction.md
@@ -55,13 +55,22 @@ each `_` is replaced by a value taken off the data stack, in order:
 ! => [ 2 3 + + ]
 ```
 
+Both `curry` and fry *consume* their values from the stack the
+moment the closure is built. The line above leaves nothing on the
+stack and is a direct replacement for `[ + + ] curry curry`.
+
+Placeholders are filled left-to-right with stack values
+bottom-to-top: `2 3 '[ _ _ ]` is `[ 2 3 ]`, not `[ 3 2 ]`.
+
 Fry also reaches *into* nested quotations, which lets you place the
 captured values exactly where you want them:
 
 ```factor
-3 '[ [ _ + ] map ] { 1 2 3 } swap call( s -- s ) .
-! => { 4 5 6 }
+2 '[ [ _ > ] filter ] { 1 2 3 4 5 } swap call( s -- s ) .
+! => { 3 4 5 }
 ```
+
+The `_` sits inside the inner `[ … ]`, but fry still fills it.
 
 ## `call` with a declared effect
 
@@ -69,7 +78,10 @@ When you ultimately run a stored quotation, declare its stack effect
 on `call` so the compiler can type-check it:
 
 ```factor
-{ 1 2 } [ first2 + ] call( p -- n ) .
+{ 3 4 5 } [ first2 + ] call( p -- n ) .
+! => 7
+
+{ 3 4 5 } [ first ] call( p -- n ) .
 ! => 3
 ```
 

--- a/exercises/concept/coordinate-choreography/coordinate-choreography/coordinate-choreography-tests.factor
+++ b/exercises/concept/coordinate-choreography/coordinate-choreography/coordinate-choreography-tests.factor
@@ -2,27 +2,27 @@ USING: coordinate-choreography exercism-tools tools.test ;
 IN: coordinate-choreography.tests
 
 TASK: 1 translate-2d
-{ { 6 8 } } [ { 4 8 } 2 0 translate-2d apply-transformation ] unit-test
+{ { 6 8 } } [ { 4 8 } 2 0 translate-2d call( p -- p' ) ] unit-test
 
 STOP-HERE
 
-{ { 4 8 } } [ { 4 8 } 0 0 translate-2d apply-transformation ] unit-test
-{ { -3 5 } } [ { 0 0 } -3 5 translate-2d apply-transformation ] unit-test
+{ { 4 8 } } [ { 4 8 } 0 0 translate-2d call( p -- p' ) ] unit-test
+{ { -3 5 } } [ { 0 0 } -3 5 translate-2d call( p -- p' ) ] unit-test
 
 TASK: 2 scale-2d
-{ { 12 -6 } } [ { 6 -3 } 2 2 scale-2d apply-transformation ] unit-test
-{ { 0 0 } } [ { 6 -3 } 0 0 scale-2d apply-transformation ] unit-test
-{ { 6 -3 } } [ { 6 -3 } 1 1 scale-2d apply-transformation ] unit-test
+{ { 12 -6 } } [ { 6 -3 } 2 2 scale-2d call( p -- p' ) ] unit-test
+{ { 0 0 } } [ { 6 -3 } 0 0 scale-2d call( p -- p' ) ] unit-test
+{ { 6 -3 } } [ { 6 -3 } 1 1 scale-2d call( p -- p' ) ] unit-test
 
 TASK: 3 compose-transformations
 { { 4 2 } } [
     { 0 1 } 2 0 translate-2d 2 2 scale-2d compose-transformations
-    apply-transformation
+    call( p -- p' )
 ] unit-test
 
 { { 2 2 } } [
     { 0 1 } 2 2 scale-2d 2 0 translate-2d compose-transformations
-    apply-transformation
+    call( p -- p' )
 ] unit-test
 
 TASK: 4 apply-transformation

--- a/exercises/practice/rotational-cipher/.meta/example.factor
+++ b/exercises/practice/rotational-cipher/.meta/example.factor
@@ -1,14 +1,15 @@
-USING: kernel locals math math.order sequences strings unicode ;
+USING: combinators fry kernel math math.order sequences ;
 IN: rotational-cipher
 
-:: rotate-char ( ch key base -- ch' )
-    ch base - key + 26 mod base + ;
+: shift-from ( base ch shift -- ch' )
+    swap pick - + 26 mod + ;
 
-:: rotate ( text key -- cipher )
-    text [| ch |
-        ch CHAR: a CHAR: z between? [ ch key CHAR: a rotate-char ] [
-            ch CHAR: A CHAR: Z between? [ ch key CHAR: A rotate-char ] [
-                ch
-            ] if
-        ] if
-    ] map ;
+: shift-char ( ch shift -- ch' )
+    {
+        { [ over CHAR: a CHAR: z between? ] [ [ CHAR: a ] 2dip shift-from ] }
+        { [ over CHAR: A CHAR: Z between? ] [ [ CHAR: A ] 2dip shift-from ] }
+        [ drop ]
+    } cond ;
+
+: rotate ( text shift -- cipher )
+    '[ _ shift-char ] map ;


### PR DESCRIPTION
The opening claim listed only `grouping` and `splitting`, but `monotonic-split` actually lives in `splitting.monotonic`

[no important files changed]