### PR TITLE
bosuns-briefing: drop locals prereq

### DIFF
--- a/bin/prereq-check
+++ b/bin/prereq-check
@@ -15,6 +15,7 @@
 #      exercise (or warned if taught by zero).
 #   5. UUIDs are unique across all exercises and concepts.
 #   6. Every practice exercise's prereq is a known concept.
+#   7. Every concept exercise has a .meta/design.md.
 #
 # Exits 0 if everything is clean, 1 otherwise.
 #
@@ -134,6 +135,12 @@ def main():
                     f'"{req}" which is not taught and not in the '
                     f'top-level concepts list'
                 )
+
+    # Check 7: every concept exercise has a .meta/design.md
+    for ex in concept_exes:
+        p = ROOT / 'exercises' / 'concept' / ex['slug'] / '.meta' / 'design.md'
+        if not p.exists():
+            errors.append(f'{ex["slug"]}: missing .meta/design.md')
 
     # Report
     for w in warnings:

--- a/config.json
+++ b/config.json
@@ -299,6 +299,21 @@
         "status": "beta"
       },
       {
+        "slug": "bosuns-briefing",
+        "name": "Bosun's Briefing",
+        "uuid": "20789ff9-130c-4ded-bbcc-567f23bffef3",
+        "concepts": [
+          "vocabularies"
+        ],
+        "prerequisites": [
+          "basics",
+          "strings",
+          "sequences",
+          "higher-order-sequences"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "pursers-pantry",
         "name": "Purser's Pantry",
         "uuid": "9e2b4530-20bc-45e7-95ac-1d93f94e258b",
@@ -310,7 +325,8 @@
           "quotations",
           "higher-order-sequences",
           "combinators",
-          "curry-compose-fry"
+          "curry-compose-fry",
+          "vocabularies"
         ],
         "status": "beta"
       },
@@ -327,7 +343,8 @@
           "assocs",
           "errors",
           "combinators",
-          "curry-compose-fry"
+          "curry-compose-fry",
+          "vocabularies"
         ],
         "status": "beta"
       },
@@ -436,22 +453,6 @@
         "status": "beta"
       },
       {
-        "slug": "bosuns-briefing",
-        "name": "Bosun's Briefing",
-        "uuid": "20789ff9-130c-4ded-bbcc-567f23bffef3",
-        "concepts": [
-          "vocabularies"
-        ],
-        "prerequisites": [
-          "basics",
-          "strings",
-          "sequences",
-          "higher-order-sequences",
-          "locals"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "quayside-crew",
         "name": "Quayside Crew",
         "uuid": "e520b985-797e-42b6-a366-990db2d58796",
@@ -476,7 +477,8 @@
           "tuples",
           "generics",
           "while",
-          "sequences"
+          "sequences",
+          "vocabularies"
         ],
         "status": "beta"
       }
@@ -1684,6 +1686,11 @@
       "name": "Errors"
     },
     {
+      "uuid": "7d0efe1a-289d-4882-a9ae-e18b0cd7b64e",
+      "slug": "vocabularies",
+      "name": "Vocabularies"
+    },
+    {
       "uuid": "4005989e-fe6b-43d8-9406-b48e0212e8ea",
       "slug": "assocs",
       "name": "Assocs"
@@ -1727,11 +1734,6 @@
       "uuid": "e9c2a584-0c03-467f-9781-38754f06dd1a",
       "slug": "generics",
       "name": "Generics"
-    },
-    {
-      "uuid": "7d0efe1a-289d-4882-a9ae-e18b0cd7b64e",
-      "slug": "vocabularies",
-      "name": "Vocabularies"
     },
     {
       "uuid": "4b136c82-48c0-4dd6-859d-e5e76c898540",

--- a/exercises/concept/annalyns-infiltration/.meta/design.md
+++ b/exercises/concept/annalyns-infiltration/.meta/design.md
@@ -1,0 +1,32 @@
+# Design
+
+## Goal
+
+Introduce the boolean literals `t`/`f`, the boolean combinators
+`and`/`or`/`not`, and the basic `kernel` shuffle words a student
+will need throughout the rest of the track.
+
+## Learning objectives
+
+- Use `t` and `f`, knowing that `f` is Factor's only falsy value.
+- Combine booleans with `and`, `or`, and `not`.
+- Reach for the right shuffle word (`dup`, `drop`, `swap`,
+  `over`, …) to line up arguments without a temporary local.
+- Compose several boolean operations inside a single `:` body.
+
+## Out of scope
+
+- Short-circuit semantics — `and`/`or` here are plain boolean
+  combinators, not conditional words.
+- `xor`, `?` (ternary), and the larger `boolean=` / `?if` family.
+- Locals (`::`, `[| … |]`); these tasks are deliberately solvable
+  with shuffle words only.
+
+## Concepts
+
+- `booleans`: `t`/`f`, `and`/`or`/`not`, and the shuffle vocabulary
+  needed to feed them their arguments.
+
+## Prerequisites
+
+- `basics` — taught in `lasagna`.

--- a/exercises/concept/bosuns-briefing/.docs/hints.md
+++ b/exercises/concept/bosuns-briefing/.docs/hints.md
@@ -39,8 +39,6 @@
   roster of the input names, and the closing.
 - `3array` (from `arrays`) packages the three values into a
   single array, ready for `"\n" join`.
-- Locals make this readable:
-  ```factor
-  :: briefing ( names -- str )
-      greeting names roster closing 3array "\n" join ;
-  ```
+- Use `[ greeting ] dip` to push the greeting *below* the names
+  already on the stack, then run `roster` on the names and
+  `closing` after — leaving three strings ready for `3array`.

--- a/exercises/concept/bosuns-briefing/.meta/design.md
+++ b/exercises/concept/bosuns-briefing/.meta/design.md
@@ -20,7 +20,6 @@ ties vocabulary names to file paths.
 - `strings` — the helpers and main both work with strings
 - `sequences` — `map`, array literals
 - `higher-order-sequences` — `[ word ] map` pattern
-- `locals` — `::` makes the briefing definition cleaner
 
 ## Why two files
 

--- a/exercises/concept/bosuns-briefing/.meta/exemplar.factor
+++ b/exercises/concept/bosuns-briefing/.meta/exemplar.factor
@@ -1,8 +1,7 @@
-USING: arrays bosuns-briefing.helpers kernel locals sequences
-splitting ;
+USING: arrays bosuns-briefing.helpers kernel sequences splitting ;
 IN: bosuns-briefing
 
 : roster ( names -- str ) [ crew-line ] map "\n" join ;
 
-:: briefing ( names -- str )
-    greeting names roster closing 3array "\n" join ;
+: briefing ( names -- str )
+    [ greeting ] dip roster closing 3array "\n" join ;

--- a/exercises/concept/pursers-pantry/.meta/design.md
+++ b/exercises/concept/pursers-pantry/.meta/design.md
@@ -26,3 +26,5 @@ inventory.
 
 - `sequences` — taught in `backyard-birdwatcher`.
 - `quotations` — introduced in `high-school-sweetheart`.
+- `vocabularies` — taught in `bosuns-briefing`. Reinforces the
+  factoring discipline before tackling a multi-task exercise.

--- a/exercises/concept/rpn-calculator/.meta/design.md
+++ b/exercises/concept/rpn-calculator/.meta/design.md
@@ -27,3 +27,6 @@ represented as an array.
 
 - `sequences` — taught in `backyard-birdwatcher`.
 - `quotations` — introduced in `high-school-sweetheart`.
+- `vocabularies` — taught in `bosuns-briefing`. The calculator
+  benefits from factoring the dispatch table and stack-evaluator
+  into separate helper words.

--- a/exercises/concept/telegraphers-tape/.meta/design.md
+++ b/exercises/concept/telegraphers-tape/.meta/design.md
@@ -22,6 +22,9 @@ mixins, and the `disposable` parent + `dispose*` cleanup hook.
 - `while` — the `stream-read1` body loops until it sees a Morse
   symbol or end-of-stream
 - `sequences` — `member?` to test the Morse alphabet
+- `vocabularies` — the stream protocol generics live in a
+  separate vocab from the tuple, so the student gets practice
+  picking the right `USING:` lines
 
 ## Why a filtering input stream
 


### PR DESCRIPTION
Rewrite `briefing` without `::`