### PR TITLE
lap-leaderboard: note that `times` lives in `math`

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "active": false,
   "status": {
     "concept_exercises": true,
-    "test_runner": true,
+    "test_runner": false,
     "representer": false,
     "analyzer": false
   },
@@ -281,7 +281,7 @@
         "prerequisites": [
           "conditionals",
           "numbers",
-          "combinators",
+          "mutation",
           "curry-compose-fry"
         ],
         "status": "beta"

--- a/exercises/concept/lap-leaderboard/.docs/introduction.md
+++ b/exercises/concept/lap-leaderboard/.docs/introduction.md
@@ -37,15 +37,16 @@ into a new sequence of the same kind as the input.
 
 ## `times` — counted iteration
 
+`times` (in [`math`][math]) runs its quotation `n` times.
+
 ```
 times ( n quot: ( -- ) -- )
 ```
 
-`times` runs its quotation `n` times. The published `( -- )`
-shape is the *minimum* — because `times` is `inline`, an
-effect-balanced quotation like `( str -- str )` works fine, and
-the stack is threaded across iterations. That gives you a
-counted accumulator without any mutable state:
+The published `( -- )` shape is the *minimum* — because `times`
+is `inline`, an effect-balanced quotation like `( str -- str )`
+works fine, and the stack is threaded across iterations. That
+gives you a counted accumulator without any mutable state:
 
 ```factor
 USING: kernel sequences ;
@@ -58,4 +59,5 @@ and leaves the new string on the stack for the next iteration.
 The same trick works for `each-index` and `map-index` when you
 want to thread an accumulator through.
 
+[math]: https://docs.factorcode.org/content/vocab-math.html
 [sequences]: https://docs.factorcode.org/content/vocab-sequences.html

--- a/exercises/concept/role-playing-game/role-playing-game/role-playing-game.factor
+++ b/exercises/concept/role-playing-game/role-playing-game/role-playing-game.factor
@@ -1,9 +1,6 @@
 USING: kernel ;
 IN: role-playing-game
 
-! TASK 1: Define the player tuple with slots
-!     name (default f), level (default 0),
-!     health (default 100), mana (default f).
 TUPLE: player ;
 
 : introduce ( player -- string )


### PR DESCRIPTION
disable test runner

[no important files changed]