### PR TITLE
print without limits

### DIFF
--- a/exercises/concept/annalyns-infiltration/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/annalyns-infiltration/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/backyard-birdcount/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/backyard-birdcount/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/backyard-birdwatcher/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/backyard-birdwatcher/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/belgian-boxcars/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/belgian-boxcars/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/bering-bearings/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/bering-bearings/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/boardwalk-games/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/boardwalk-games/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/boatswains-bilge/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/boatswains-bilge/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/bosuns-briefing/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/bosuns-briefing/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/boutique-bookkeeping/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/boutique-bookkeeping/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/bunting-bonanza/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/bunting-bonanza/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/cargo-shuffle/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/cargo-shuffle/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/cars-assemble/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/cars-assemble/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/channel-chatter/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/channel-chatter/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/character-study/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/character-study/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/coordinate-choreography/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/coordinate-choreography/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/currency-conversion/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/currency-conversion/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/dragons-descendants/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/dragons-descendants/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/factory-failsafe/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/factory-failsafe/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/ferry-schedule/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/ferry-schedule/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/garden-gathering/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/garden-gathering/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/high-school-sweetheart/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/high-school-sweetheart/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/joiners-journey/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/joiners-journey/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/lap-leaderboard/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/lap-leaderboard/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/lasagna-luminary/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/lasagna-luminary/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/lasagna/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/lasagna/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/librarians-ledger/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/librarians-ledger/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/lighthouse-logbook/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/lighthouse-logbook/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/log-levels/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/log-levels/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/mixed-juices/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/mixed-juices/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/mixtape-maker/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/mixtape-maker/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/mosaic-making/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/mosaic-making/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/mosaic-mischief/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/mosaic-mischief/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/pirates-path/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/pirates-path/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/pursers-pantry/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/pursers-pantry/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/quayside-crew/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/quayside-crew/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/role-playing-game/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/role-playing-game/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/rpn-calculator/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/rpn-calculator/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/secrets/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/secrets/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/signal-stencils/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/signal-stencils/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/signalers-satchel/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/signalers-satchel/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/telegraphers-tape/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/telegraphers-tape/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/valentines-day/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/valentines-day/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/concept/vltava-weather-watch/exercism-tools/exercism-tools.factor
+++ b/exercises/concept/vltava-weather-watch/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/accumulate/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/accumulate/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/acronym/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/acronym/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/affine-cipher/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/affine-cipher/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/all-your-base/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/all-your-base/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/allergies/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/allergies/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/alphametics/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/alphametics/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/anagram/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/anagram/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/armstrong-numbers/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/armstrong-numbers/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/atbash-cipher/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/atbash-cipher/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/bank-account/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/bank-account/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/binary-search-tree/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/binary-search-tree/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/binary-search/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/binary-search/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/bob/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/bob/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/book-store/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/book-store/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/bottle-song/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/bottle-song/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/change/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/change/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/circular-buffer/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/circular-buffer/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/clock/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/clock/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/collatz-conjecture/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/collatz-conjecture/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/complex-numbers/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/complex-numbers/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/connect/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/connect/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/crypto-square/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/crypto-square/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/custom-set/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/custom-set/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/darts/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/darts/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/diamond/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/diamond/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/difference-of-squares/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/difference-of-squares/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/dnd-character/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/dnd-character/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/dominoes/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/dominoes/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/eliuds-eggs/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/eliuds-eggs/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/etl/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/etl/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/flatten-array/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/flatten-array/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/flower-field/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/flower-field/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/food-chain/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/food-chain/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/game-of-life/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/game-of-life/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/gigasecond/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/gigasecond/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/grade-school/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/grade-school/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/grains/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/grains/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/grep/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/grep/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/hamming/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/hamming/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/hello-world/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/hello-world/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/high-scores/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/high-scores/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/house/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/house/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/intergalactic-transmission/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/intergalactic-transmission/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/isbn-verifier/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/isbn-verifier/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/isogram/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/isogram/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/killer-sudoku-helper/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/killer-sudoku-helper/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/kindergarten-garden/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/kindergarten-garden/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/knapsack/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/knapsack/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/largest-series-product/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/largest-series-product/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/leap/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/leap/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/line-up/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/line-up/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/list-ops/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/list-ops/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/luhn/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/luhn/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/matching-brackets/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/matching-brackets/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/matrix/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/matrix/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/meetup/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/meetup/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/micro-blog/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/micro-blog/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/nth-prime/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/nth-prime/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/nucleotide-count/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/nucleotide-count/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/ocr-numbers/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/ocr-numbers/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/paasio/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/paasio/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/palindrome-products/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/palindrome-products/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/pangram/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/pangram/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/parallel-letter-frequency/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/parallel-letter-frequency/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/pascals-triangle/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/pascals-triangle/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/perfect-numbers/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/perfect-numbers/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/phone-number/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/phone-number/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/piecing-it-together/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/piecing-it-together/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/pig-latin/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/pig-latin/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/prime-factors/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/prime-factors/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/protein-translation/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/protein-translation/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/proverb/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/proverb/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/pythagorean-triplet/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/pythagorean-triplet/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/queen-attack/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/queen-attack/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/rail-fence-cipher/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/rail-fence-cipher/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/raindrops/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/raindrops/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/rational-numbers/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/rational-numbers/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/rectangles/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/rectangles/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/relative-distance/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/relative-distance/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/resistor-color-duo/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/resistor-color-duo/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/resistor-color-trio/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/resistor-color-trio/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/resistor-color/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/resistor-color/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/reverse-string/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/reverse-string/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/rna-transcription/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/rna-transcription/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/robot-name/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/robot-name/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/robot-simulator/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/robot-simulator/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/roman-numerals/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/roman-numerals/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/rotational-cipher/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/rotational-cipher/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/run-length-encoding/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/run-length-encoding/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/saddle-points/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/saddle-points/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/satellite/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/satellite/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/save-the-cow/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/save-the-cow/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/say/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/say/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/scrabble-score/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/scrabble-score/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/series/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/series/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/sieve/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/sieve/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/simple-linked-list/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/simple-linked-list/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/space-age/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/space-age/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/spiral-matrix/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/spiral-matrix/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/split-second-stopwatch/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/split-second-stopwatch/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/square-root/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/square-root/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/sublist/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/sublist/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/sum-of-multiples/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/sum-of-multiples/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/tournament/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/tournament/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/triangle/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/triangle/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/twelve-days/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/twelve-days/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/two-bucket/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/two-bucket/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/two-fer/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/two-fer/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/variable-length-quantity/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/variable-length-quantity/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/word-count/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/word-count/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/word-search/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/word-search/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/wordy/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/wordy/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/yacht/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/yacht/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/exercises/practice/zebra-puzzle/exercism-tools/exercism-tools.factor
+++ b/exercises/practice/zebra-puzzle/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 

--- a/lib/exercism-tools/exercism-tools.factor
+++ b/lib/exercism-tools/exercism-tools.factor
@@ -1,6 +1,7 @@
 USING: accessors command-line continuations debugger io kernel
-       lexer namespaces sequences source-files.errors.debugger
-       system tools.test vocabs vocabs.loader ;
+       lexer namespaces prettyprint.config sequences
+       source-files.errors.debugger system tools.test vocabs
+       vocabs.loader ;
 IN: exercism-tools
 
 SYNTAX: STOP-HERE
@@ -17,7 +18,7 @@ SYNTAX: TASK:
 :: print-failure ( failure -- )
     "###FAIL_BEGIN###" print
     failure error-location print
-    failure error>> [ error. ] [ 2drop ] recover
+    [ failure error>> [ error. ] [ 2drop ] recover ] without-limits
     "###FAIL_END###" print
     flush ;
 


### PR DESCRIPTION
Previously, we sometimes reported `{ ~array~ ~array~ ~array~ … }` instead of the nested array contents.